### PR TITLE
Use Custom Thumbnail on Table of Contents Cards

### DIFF
--- a/src/Site/BlockLayout/ExhibitContents.php
+++ b/src/Site/BlockLayout/ExhibitContents.php
@@ -64,7 +64,11 @@ class ExhibitContents extends AbstractBlockLayout
                             $media = $attachment->item()->primaryMedia();
                         }
                         if ($media){
-                            $img = $media->thumbnailUrl($size);
+                            if ($thumbnail = $media->thumbnail()) {
+                                $img = $thumbnail->assetUrl();
+                            } else {
+                                $img = $media->thumbnailUrl($size);
+                            }
                             if (array_key_exists('o-module-alt-text:alt-text', $media->primaryMedia()->jsonSerialize())
                                 && $media->primaryMedia()->jsonSerialize()['o-module-alt-text:alt-text']
                             ) {

--- a/src/Site/BlockLayout/ListOfExhibits.php
+++ b/src/Site/BlockLayout/ListOfExhibits.php
@@ -81,7 +81,11 @@ class ListOfExhibits extends AbstractBlockLayout
                                     $media = $attachment->item()->primaryMedia();
                                 }
                                 if ($media){
-                                    $img = $media->thumbnailUrl($size);
+                                    if ($thumbnail = $media->thumbnail()) {
+                                        $img = $thumbnail->assetUrl();
+                                    } else {
+                                        $img = $media->thumbnailUrl($size);
+                                    }
                                     if (array_key_exists('o-module-alt-text:alt-text', $media->primaryMedia()->jsonSerialize())
                                         && $media->primaryMedia()->jsonSerialize()['o-module-alt-text:alt-text']
                                     ) {


### PR DESCRIPTION
This resolves #1. The theme now uses a custom thumbnail a user has set for a media resource if one is present, otherwise it will use the 'large' image derivative like it did before.

This uses similar code to the theme pull request at this link: https://github.com/UIUCLibrary/ksharp/pull/10